### PR TITLE
fix: Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,13 @@ jobs:
           RAILS_ENV: test
           DB_HOST: 127.0.0.1
       - image: circleci/mysql:5.7.33
-        environment:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: app_test
 
     working_directory: ~/repo
 
     steps:
       - checkout
 
+      # Wait for the DB image to start up
       - run:
           name: Install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz


### PR DESCRIPTION
# 発生したエラー

CircleCi のapiテストがfailedになる

# 結論

DB が立ち上がる前にテストを実行していたのが原因だったので、
DB の立ち上がりを待ってからテストを実行するとエラー解消できた！！:smiley:

DB の立ち上がりを待つのに、Dockerize を使います！

```yml
# Wait for the DB image to start up
  - run:
      name: Install dockerize
      command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
      environment:
        DOCKERIZE_VERSION: v0.6.1
  - run:
      name: Wait for DB
      command: dockerize -wait tcp://127.0.0.1:3306 -timeout 3m

```

# 参考

このページがなかったらエラー解決できませんでした！:sob:

ref: CircleCIでmysql8を使用する設定
https://carefree-se.hatenablog.com/entry/2019/02/12/223417
