### PR TITLE
feat: Update markdown

### DIFF
--- a/front/components/atoms/BaseMarkdown.vue
+++ b/front/components/atoms/BaseMarkdown.vue
@@ -6,7 +6,6 @@
       class="mavonEditor"
       language="ja"
       :toolbars="markdownOption"
-      :scrollStyle="false"
       :boxShadow="false"
       placeholder="Write in Markdown"
       @imgAdd="$imgAdd"
@@ -73,8 +72,8 @@ export default {
 <style scoped>
 .mavonEditor {
   margin: auto;
-  width: 90vw;
-  height: 70vh;
+  width: 100%;
+  height: 100%;
   position: relative;
   z-index: 0;
 }

--- a/front/components/atoms/BaseMarkdown.vue
+++ b/front/components/atoms/BaseMarkdown.vue
@@ -38,7 +38,6 @@ export default {
         imagelink: true,
         code: true,
         table: true,
-        trash: true,
         preview: true
       }
     }

--- a/front/components/atoms/BaseMarkdown.vue
+++ b/front/components/atoms/BaseMarkdown.vue
@@ -1,16 +1,16 @@
 <template>
-  <no-ssr>
-    <mavon-editor
-      ref="md"
-      v-model="inputValue"
-      class="mavonEditor"
-      language="ja"
-      :toolbars="markdownOption"
-      :boxShadow="false"
-      placeholder="Write in Markdown"
-      @imgAdd="$imgAdd"
-    />
-  </no-ssr>
+  <mavon-editor
+    ref="md"
+    v-model="inputValue"
+    class="mavonEditor"
+    language="ja"
+    :toolbars="markdownOption"
+    :boxShadow="false"
+    :subfield="false"
+    defaultOpen="edit"
+    placeholder="Write in Markdown"
+    @imgAdd="$imgAdd"
+  />
 </template>
 <script>
 export default {

--- a/front/components/atoms/BaseMarkdown.vue
+++ b/front/components/atoms/BaseMarkdown.vue
@@ -38,7 +38,8 @@ export default {
         imagelink: true,
         code: true,
         table: true,
-        trash: true
+        trash: true,
+        preview: true
       }
     }
   },

--- a/front/components/atoms/BaseMarkdownPreview.vue
+++ b/front/components/atoms/BaseMarkdownPreview.vue
@@ -41,7 +41,7 @@ export default {
 .markdown__preview {
   padding: auto 12 auto;
   width: 100%;
-  height: 70vh;
+  height: 100%;
   position: relative;
     /* FIXME: z-indexが反映されてない */
   z-index: 0;


### PR DESCRIPTION
closed #90 
## 実装した内容

- マークダウンをアップデート

### front

- height="100%" width="100%"に変更
- デフォルトでは編集エリアが表示されるよう変更
- 表示するエリアを変更できるトグルを追加
- シンタックスハイライトを追加

## ユーザーから見た挙動

- テキストエリアのサイズが入力する長さに応じて長くなる
- デフォルトでは編集エリアが表示される
- トグルで表示するエリアを変更できる: 編集エリア <-> プレビューエリア
- コードブロックではシンタックスハイライトが表示される

## 実装前後のスクリーンショット

### 実装前
![localhost_8080_2_works_12 (1)](https://user-images.githubusercontent.com/63993873/111752255-d141dc80-88d8-11eb-9cd7-0c666e82100c.png)

### 実装後
![localhost_8080_user0_works_12_edit](https://user-images.githubusercontent.com/63993873/111752333-ea4a8d80-88d8-11eb-8520-914de51db67d.png)