### PR TITLE
feat: Add dashboard 

### DIFF
--- a/api/app/controllers/api/v1/works_controller.rb
+++ b/api/app/controllers/api/v1/works_controller.rb
@@ -22,6 +22,7 @@ class Api::V1::WorksController < ApplicationController
   end
 
   def destroy
+    @work = Work.find(params[:id])
     @work.destroy
   end
 

--- a/api/db/seeds/development/works.rb
+++ b/api/db/seeds/development/works.rb
@@ -1,1 +1,1 @@
-5.times{ create(:work) }
+5.times{ create(:private) }

--- a/api/spec/factories/works.rb
+++ b/api/spec/factories/works.rb
@@ -1,8 +1,14 @@
 FactoryBot.define do
-  factory :work do
+  factory :public, class: Work do
     sequence(:title) { |n| "タイトル #{n}" }
     body { "# 見出し1\n**複素数体**であれば、*任意のCM-タイプ*の A は、実際、++数体である定義体++（英語版）(==field of definition==)を持っている。自己準同型環の可能なタイプは、対合（ロサチの対合（英語版）(Rosati involution）をもつ環として既に分類さ\n## 見出し2\n1. リスト1\n2. リスト2\n3. リスト3\n### 見出し3\n- リスト1\n- リスト2\n- リスト3\n- \n#### 見出し4\n```1行のコード```\n\n```js:javascript\n複数のコード\n複数のコード\n複数のコード\n```\n##### 見出し5\n[google](https://google.com)\n\n###### 見出し6\n|column1|column2|column3|\n|-|-|-|\n|content1|content2|content3|\n\n\n" }
-    is_public { 1 }
+    is_public { true }
+    user_id { 2 }
+  end
+  factory :private, class: Work do
+    sequence(:title) { |n| "下書きタイトル #{n}" }
+    body { "# 見出し1\n**複素数体**であれば、*任意のCM-タイプ*の A は、実際、++数体である定義体++（英語版）(==field of definition==)を持っている。自己準同型環の可能なタイプは、対合（ロサチの対合（英語版）(Rosati involution）をもつ環として既に分類さ\n## 見出し2\n1. リスト1\n2. リスト2\n3. リスト3\n### 見出し3\n- リスト1\n- リスト2\n- リスト3\n- \n#### 見出し4\n```1行のコード```\n\n```js:javascript\n複数のコード\n複数のコード\n複数のコード\n```\n##### 見出し5\n[google](https://google.com)\n\n###### 見出し6\n|column1|column2|column3|\n|-|-|-|\n|content1|content2|content3|\n\n\n" }
+    is_public { false }
     user_id { 2 }
   end
 end

--- a/front/components/atoms/BaseCardForDashboard.vue
+++ b/front/components/atoms/BaseCardForDashboard.vue
@@ -25,13 +25,7 @@ export default {
       type: String,
       default: ''
     }
-  },
-  methods: {
-    deleteWork () {
-      this.$axios.delete('`hoge`')
-    }
   }
-
 }
 </script>
 

--- a/front/components/atoms/BaseCardForDashboard.vue
+++ b/front/components/atoms/BaseCardForDashboard.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-card
+    class="mx-auto"
+    color="transparent"
+    elevation="1"
+    :to="to"
+    nuxt
+  >
+    <v-row no-gutters>
+      <v-col sm="10">
+        <v-card-title>
+          <div class="mx-3 text-subtitle-1 font-weight-bold">
+            <slot name="title" />
+          </div>
+        </v-card-title>
+      </v-col>
+    </v-row>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: {
+    to: {
+      type: String,
+      default: ''
+    }
+  },
+  methods: {
+    deleteWork () {
+      this.$axios.delete('`hoge`')
+    }
+  }
+
+}
+</script>
+
+<style>
+
+</style>

--- a/front/components/atoms/BaseCardForDashboard.vue
+++ b/front/components/atoms/BaseCardForDashboard.vue
@@ -7,9 +7,26 @@
     nuxt
   >
     <v-row no-gutters>
+      <v-col sm="2" align-self="center">
+        <v-chip
+          v-if="!isPublic"
+          small
+          class="ml-2"
+        >
+          下書き
+        </v-chip>
+        <v-chip
+          v-else
+          small
+          class="ml-2"
+          color="primary"
+        >
+          公開中
+        </v-chip>
+      </v-col>
       <v-col sm="10">
-        <v-card-title>
-          <div class="mx-3 text-subtitle-1 font-weight-bold">
+        <v-card-title class="pl-0">
+          <div class="text-subtitle-1 font-weight-bold">
             <slot name="title" />
           </div>
         </v-card-title>
@@ -24,6 +41,10 @@ export default {
     to: {
       type: String,
       default: ''
+    },
+    isPublic: {
+      type: Boolean,
+      default: false
     }
   }
 }

--- a/front/components/atoms/BaseDialog.vue
+++ b/front/components/atoms/BaseDialog.vue
@@ -70,7 +70,12 @@ export default {
       })
     },
     deleteWork () {
-      this.$emit('deleteWork')
+      this.$axios.delete(`/api/v1/works/${this.$route.params.id}`)
+        .then(
+          setTimeout(() => {
+            this.$router.push(`/${this.$auth.user.name}/works`)
+          }, 1000)
+        )
     }
   }
 }

--- a/front/components/atoms/BaseDialog.vue
+++ b/front/components/atoms/BaseDialog.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="text-center">
+    <v-dialog
+      v-model="dialog"
+      width="500"
+    >
+      <template #activator="{ on, attrs }">
+        <v-btn
+          v-bind="attrs"
+          small
+          fab
+          elevation="1"
+          rounded
+          v-on="on"
+          @click="dialogOpen"
+        >
+          <v-icon color="grey">
+            mdi-trash-can-outline
+          </v-icon>
+        </v-btn>
+      </template>
+
+      <v-card>
+        <v-card-title class="text-h6">
+          削除しますか？
+        </v-card-title>
+
+        <v-card-text>
+          Workを削除しようとしています。
+          1度削除するとデータを復元することはできません。
+        </v-card-text>
+
+        <v-divider />
+
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            ref="cancel"
+            color="blue"
+            text
+            @click="dialog = false"
+          >
+            キャンセル
+          </v-btn>
+          <v-btn
+            color="red"
+            text
+            @click="deleteWork"
+          >
+            削除する
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      dialog: false
+    }
+  },
+  methods: {
+    dialogOpen () {
+      // キャンセルボタンにフォーカスする
+      setTimeout(() => {
+        this.$refs.cancel.$el.focus()
+      })
+    },
+    deleteWork () {
+      this.$emit('deleteWork')
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/front/components/organisms/TheHeaderAfterLogin.vue
+++ b/front/components/organisms/TheHeaderAfterLogin.vue
@@ -84,6 +84,17 @@
 
           <v-list-item>
             <v-list-item-title>
+              <v-icon>mdi-file-edit-outline</v-icon>
+              <nuxt-link
+                :to="`/${$auth.user.name}/works`"
+                class='text-decoration-none black--text pl-1'
+              >
+                作品の管理
+              </nuxt-link>
+            </v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-title>
               <v-icon>mdi-cog</v-icon>
               <nuxt-link
                 :to="`/${$auth.user.name}/settings`"

--- a/front/pages/_username/works/_id/edit.vue
+++ b/front/pages/_username/works/_id/edit.vue
@@ -30,6 +30,10 @@
       </ValidationObserver>
     </v-form>
     <v-row justify='center'>
+      <!-- TODO: 以下のボタンはヘッダーに表示させたほうがいいかもしれない -->
+      <v-card-actions>
+        <BaseDialog />
+      </v-card-actions>
       <v-spacer />
       <div class="my-auto mx-3">
         <v-switch
@@ -56,12 +60,14 @@ import BaseTextField from '@/components/atoms/BaseTextField.vue'
 import BaseMarkdown from '@/components/atoms/BaseMarkdown.vue'
 import BaseButton from '@/components/atoms/BaseButton.vue'
 import BaseTagInput from '@/components/atoms/BaseTagInput.vue'
+import BaseDialog from '@/components/atoms/BaseDialog.vue'
 export default {
   components: {
     BaseTextField,
     BaseMarkdown,
     BaseButton,
-    BaseTagInput
+    BaseTagInput,
+    BaseDialog
   },
   data () {
     return {

--- a/front/pages/_username/works/index.vue
+++ b/front/pages/_username/works/index.vue
@@ -7,7 +7,6 @@
         </div>
       </v-col>
     </v-row>
-    {{ works }}
     <v-row>
       <v-col>
         <v-card
@@ -71,18 +70,11 @@ export default {
       works: []
     }
   },
-  created () {
+  mounted () {
     this.$axios.get(`/api/v1/works/?user_id=${this.$auth.user.id}`)
       .then((res) => {
         this.works = res.data
       })
-  },
-  methods: {
-    deleteWork () {
-      // フロントでWorkカードを削除
-
-      // データを削除するリクエストをapiに投げる
-    }
   }
 }
 </script>

--- a/front/pages/_username/works/index.vue
+++ b/front/pages/_username/works/index.vue
@@ -1,0 +1,90 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col>
+        <div class="text-h4 font-weight-bold">
+          Works
+        </div>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        <v-card
+          flat
+        >
+          <v-tabs
+            v-model="tab"
+            slider-color="primary"
+          >
+            <v-tabs-slider color="primary" />
+            <v-tab>
+              <div class="text-none">
+                すべて
+              </div>
+            </v-tab>
+            <v-tab>
+              <div class="text-none">
+                公開
+              </div>
+            </v-tab>
+            <v-tab>
+              <div class="text-none">
+                下書き
+              </div>
+            </v-tab>
+
+            <v-tab-item class="my-4">
+              <v-row class="mx-4">
+                <v-col
+                  v-for="work in works"
+                  :key="work.id"
+                  cols="12"
+                >
+                  <BaseCardForDashboard
+                    :to="`/${$route.params.username}/works/${work.id}/edit`"
+                  >
+                    <template #title>
+                      {{ work.title }}
+                    </template>
+                  </BaseCardForDashboard>
+                </v-col>
+              </v-row>
+            </v-tab-item>
+          </v-tabs>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import BaseCardForDashboard from '@/components/atoms/BaseCardForDashboard.vue'
+export default {
+  components: {
+    BaseCardForDashboard
+  },
+  data () {
+    return {
+      tab: null,
+      works: []
+    }
+  },
+  created () {
+    this.$axios.get(`/api/v1/works/?user_id=${this.$auth.user.id}`)
+      .then((res) => {
+        this.works = res.data
+      })
+  },
+  methods: {
+    deleteWork () {
+      // フロントでWorkカードを削除
+
+      // データを削除するリクエストをapiに投げる
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/front/pages/_username/works/index.vue
+++ b/front/pages/_username/works/index.vue
@@ -7,6 +7,7 @@
         </div>
       </v-col>
     </v-row>
+    {{ works }}
     <v-row>
       <v-col>
         <v-card
@@ -24,7 +25,7 @@
             </v-tab>
             <v-tab>
               <div class="text-none">
-                公開
+                公開中
               </div>
             </v-tab>
             <v-tab>
@@ -42,6 +43,7 @@
                 >
                   <BaseCardForDashboard
                     :to="`/${$route.params.username}/works/${work.id}/edit`"
+                    :isPublic="work.is_public"
                   >
                     <template #title>
                       {{ work.title }}

--- a/front/pages/_username/works/index.vue
+++ b/front/pages/_username/works/index.vue
@@ -7,6 +7,7 @@
         </div>
       </v-col>
     </v-row>
+    {{ workPublic }}
     <v-row>
       <v-col>
         <v-card
@@ -23,17 +24,20 @@
               </div>
             </v-tab>
             <v-tab>
-              <div class="text-none">
+              <div class="text-none" @click="filterWorkPublic">
                 公開中
               </div>
             </v-tab>
             <v-tab>
-              <div class="text-none">
+              <div class="text-none" @click="filterWorkPrivate">
                 下書き
               </div>
             </v-tab>
 
-            <v-tab-item class="my-4">
+            <v-tab-item
+
+              class="my-4"
+            >
               <v-row class="mx-4">
                 <v-col
                   v-for="work in works"
@@ -46,6 +50,45 @@
                   >
                     <template #title>
                       {{ work.title }}
+                    </template>
+                  </BaseCardForDashboard>
+                </v-col>
+              </v-row>
+            </v-tab-item>
+            <v-tab-item class="my-4">
+              <v-row class="mx-4">
+                <v-col
+                  v-for="workPublic in worksPublic"
+                  :key="workPublic.id"
+                  cols="12"
+                >
+                  <BaseCardForDashboard
+                    :to="`/${$route.params.username}/works/${workPublic.id}/edit`"
+                    :isPublic="workPublic.is_public"
+                  >
+                    <template #title>
+                      {{ workPublic.title }}
+                    </template>
+                  </BaseCardForDashboard>
+                </v-col>
+              </v-row>
+            </v-tab-item>
+            <v-tab-item
+
+              class="my-4"
+            >
+              <v-row class="mx-4">
+                <v-col
+                  v-for="workPrivate in worksPrivate"
+                  :key="workPrivate.id"
+                  cols="12"
+                >
+                  <BaseCardForDashboard
+                    :to="`/${$route.params.username}/works/${workPrivate.id}/edit`"
+                    :isPublic="workPrivate.is_public"
+                  >
+                    <template #title>
+                      {{ workPrivate.title }}
                     </template>
                   </BaseCardForDashboard>
                 </v-col>
@@ -67,7 +110,9 @@ export default {
   data () {
     return {
       tab: null,
-      works: []
+      works: [],
+      worksPublic: [],
+      worksPrivate: []
     }
   },
   mounted () {
@@ -75,6 +120,14 @@ export default {
       .then((res) => {
         this.works = res.data
       })
+  },
+  methods: {
+    filterWorkPublic () {
+      this.worksPublic = this.works.filter(work => work.is_public === true)
+    },
+    filterWorkPrivate () {
+      this.worksPrivate = this.works.filter(work => work.is_public === false)
+    }
   }
 }
 </script>

--- a/front/pages/_username/works/index.vue
+++ b/front/pages/_username/works/index.vue
@@ -7,7 +7,6 @@
         </div>
       </v-col>
     </v-row>
-    {{ workPublic }}
     <v-row>
       <v-col>
         <v-card


### PR DESCRIPTION
closed #89 
## 実装した内容

- 作品の管理機能(dashboard)を追加

### front
- メニューリストに作品の管理を追加する
- dashboardページを追加
- 作品の公開ステータを表示

## api
- deleteメソッドを編集
- seedデータ用のfactory botを編集

## ユーザーから見た挙動

- アイコンボタンを押すとメニューが開かれ、"作品の管理"の項目がある
- 作品の管理を押すと、作品全てが表示される(公開、下書きどちらも)
- 各作品の項目にタイトルと公開ステータスが表示される
- 作品を押すと、編集画面に遷移する

## 実装前後のスクリーンショット
### 実装前
![localhost_8080_user0_works (1)](https://user-images.githubusercontent.com/63993873/111865353-f18d9c00-89a9-11eb-8167-07c3c2b23b9b.png)

### 実装後
![localhost_8080_user0_works](https://user-images.githubusercontent.com/63993873/111865359-f8b4aa00-89a9-11eb-85a1-f01281b7af15.png)
